### PR TITLE
Added support for R&S ZNB20 VNA and FSV spectrum analyzer in 269

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,7 +2,7 @@ julia 0.6
 ICCommon
 ICDataServer
 VISA
-Alazar
+#Alazar
 KeysightInstruments
 BinDeps
 FileIO

--- a/deps/instruments/E5071C.json
+++ b/deps/instruments/E5071C.json
@@ -45,7 +45,7 @@
         },
         {
             "cmd": ":CALCch:TRACtr:FORM",
-            "type": "VNA.Format",
+            "type": "Format",
             "values": [
                 "v::Symbol in symbols"
             ],

--- a/deps/instruments/E8257D.json
+++ b/deps/instruments/E8257D.json
@@ -139,7 +139,7 @@
             ]
         }, {
             "cmd":"SOUR:POW",
-            "type":"Power",
+            "type":"PowerLevel",
             "values":[
                 "v::Real"
             ]

--- a/deps/instruments/FSV.json
+++ b/deps/instruments/FSV.json
@@ -57,7 +57,7 @@
             ]
         },
         {
-            "cmd": ":SENSch:AVER:TYPE",
+            "cmd": ":SENS:AVER:TYPE",
             "type": "AveragingMode",
             "values": [
                 "v::Symbol in symbols"
@@ -141,23 +141,13 @@
             ]
         },
         {
-            "cmd": ":CALCch:SMO",
-            "type": "Smoothing",
-            "values": [
-                "v::Bool"
-            ],
-            "infixes": [
-                "ch::Integer=1",
-            ]
-        },
-        {
             "cmd": ":FORM:DATA",
             "type": "TransferFormat",
             "values": [
                 "v::Symbol in symbols"
             ],
             "symbols": {
-                "String": "ASC",
+                "String": "ASCII",
                 "Float32": "REAL,32"
             }
         },
@@ -171,5 +161,13 @@
                 "InternalTrigger": "IMM",
                 "ExternalTrigger": "EXT"
             }
+        },
+        {
+            "cmd": ":DISP:TRAC:Y:RLEV",
+            "type": "ReferenceLevel",
+            "values": [
+                "v::Real"
+            ]
         }
     ]
+}

--- a/deps/instruments/FSV.json
+++ b/deps/instruments/FSV.json
@@ -1,0 +1,175 @@
+{
+    "instrument": {
+        "module": "FSV",
+        "type": "InsFSV",
+        "super": "Instrument",
+        "make": "Rohde&Schwarz",
+        "model": "FSV",
+        "writeterminator": "\n"
+    },
+    "properties": [
+        {
+            "cmd": ":SENS:SWE:TIME:AUTO",
+            "type": "AutoSweepTime",
+            "values": [
+                "v::Bool"
+            ]
+        },
+        {
+            "cmd": ":SENS:SWE:TIME",
+            "type": "SweepTime",
+            "values": [
+                "v::Real"
+            ]
+        },
+        {
+            "cmd": ":UNIT:POW",
+            "type": "Format",
+            "values": [
+                "v::Symbol in symbols"
+            ],
+            "symbols": {
+                "dBm": "DBM",
+                "dBmV": "DBMV",
+                "dBμV": "DBUV",
+                "dBμA": "DBUA",
+                "dBpW": "DBPW",
+                "Volt": "VOLT",
+                "Ampere": "AMP",
+                "Watt": "W"
+            }
+        },
+        {
+            "cmd": ":SENS:AVER:STATtr",
+            "type": "Averaging",
+            "values": [
+                "v::Bool"
+            ],
+            "infixes": [
+                "tr::Integer=1"
+            ]
+        },
+        {
+            "cmd": ":SENS:AVER:COUN",
+            "type": "AveragingFactor",
+            "values": [
+                "v::Integer"
+            ]
+        },
+        {
+            "cmd": ":SENSch:AVER:TYPE",
+            "type": "AveragingMode",
+            "values": [
+                "v::Symbol in symbols"
+            ],
+            "symbols": {
+                "Log": "VID",
+                "LinearUnit": "LIN",
+                "Power": "POW"
+            }
+        },
+        {
+            "cmd": ":SENS:FREQ:STAR",
+            "type": "FrequencyStart",
+            "values": [
+                "v::Real"
+            ]
+        },
+        {
+            "cmd": ":SENS:FREQ:STOP",
+            "type": "FrequencyStop",
+            "values": [
+                "v::Real"
+            ]
+        },
+        {
+            "cmd": ":SENS:FREQ:CENT",
+            "type": "FrequencyCenter",
+            "values": [
+                "v::Real"
+            ]
+        },
+        {
+            "cmd": ":SENS:FREQ:SPAN",
+            "type": "FrequencySpan",
+            "values": [
+                "v::Real"
+            ]
+        },
+        {
+            "cmd": ":SENS:BAND",
+            "type": "Bandwidth",
+            "values": [
+                "v::Real"
+            ]
+        },
+        {
+            "cmd": ":SENS:BAND:AUTO",
+            "type": "AutoBandwidth",
+            "values": [
+                "v::Bool"
+            ]
+        },
+        {
+            "cmd": ":SENS:BAND:TYPE",
+            "type": "FilterType",
+            "values": [
+                "v::Symbol in symbols"
+            ],
+            "symbols": {
+                "Normal": "NORM",
+                "Channel": "CFIL",
+                "RRC": "RRC",
+                "FivePole": "P5"
+            }
+        },
+        {
+            "cmd": ":SENS:SWE:POIN",
+            "type": "NumPoints",
+            "values": [
+                "v::Integer"
+            ]
+        },
+        {
+            "cmd": ":DISP:TRACtr:STAT",
+            "type": "TraceDisplay",
+            "values": [
+                "v::AbstractString"
+            ],
+            "infixes": [
+                "tr::Integer=1"
+            ]
+        },
+        {
+            "cmd": ":CALCch:SMO",
+            "type": "Smoothing",
+            "values": [
+                "v::Bool"
+            ],
+            "infixes": [
+                "ch::Integer=1",
+            ]
+        },
+        {
+            "cmd": ":FORM:DATA",
+            "type": "TransferFormat",
+            "values": [
+                "v::Symbol in symbols"
+            ],
+            "symbols": {
+                "String": "ASC",
+                "Float32": "REAL,32"
+            }
+        },
+        {
+            "cmd": ":TRIG:SOUR",
+            "type": "TriggerSource",
+            "values": [
+                "v::Symbol in symbols"
+            ],
+            "symbols": {
+                "InternalTrigger": "IMM",
+                "ExternalTrigger": "EXT"
+            }
+        }
+    ]

--- a/deps/instruments/FSV.json
+++ b/deps/instruments/FSV.json
@@ -40,18 +40,8 @@
             }
         },
         {
-            "cmd": ":SENS:AVER:STATtr",
-            "type": "Averaging",
-            "values": [
-                "v::Bool"
-            ],
-            "infixes": [
-                "tr::Integer=1"
-            ]
-        },
-        {
-            "cmd": ":SENS:AVER:COUN",
-            "type": "AveragingFactor",
+            "cmd": ":SENS:SWE:COUN",
+            "type": "SweepCount",
             "values": [
                 "v::Integer"
             ]

--- a/deps/instruments/ZNB20.json
+++ b/deps/instruments/ZNB20.json
@@ -1,0 +1,242 @@
+{
+    "instrument": {
+        "module": "ZNB20",
+        "type": "InsZNB20",
+        "super": "Instrument",
+        "make": "Rohde&Schwarz",
+        "model": "ZNB20",
+        "writeterminator": "\n"
+    },
+    "properties": [
+        {
+            "cmd": ":SENSch:SWE:TIME:AUTO",
+            "type": "AutoSweepTime",
+            "values": [
+                "v::Bool"
+            ],
+            "infixes": [
+                "ch::Integer=1"
+            ]
+        },
+        {
+            "cmd": ":SENSch:SWE:TIME",
+            "type": "SweepTime",
+            "values": [
+                "v::Real"
+            ],
+            "infixes": [
+                "ch::Integer=1"
+            ]
+        },
+        {
+            "cmd": ":CALCch:FORM",
+            "type": "Format",
+            "values": [
+                "v::Symbol in symbols"
+            ],
+            "symbols": {
+                "LogMagnitude": "MLOG",
+                "Phase": "PHAS",
+                "GroupDelay": "GDEL",
+                "Smith": "SMIT",
+                "SmithAdmittance": "ISM",
+                "PolarLinear": "POL",
+                "LinearMagnitude": "MLIN",
+                "SWR": "SWR",
+                "RealPart": "REAL",
+                "ImagPart": "IMAG",
+                "ExpandedPhase": "UPH",
+            },
+            "infixes": [
+                "ch::Integer=1"
+            ]
+        },
+        {
+            "cmd": ":SENSch:AVER",
+            "type": "Averaging",
+            "values": [
+                "v::Bool"
+            ],
+            "infixes": [
+                "ch::Integer=1"
+            ]
+        },
+        {
+            "cmd": ":SENSch:AVER:COUN",
+            "type": "AveragingFactor",
+            "values": [
+                "v::Integer"
+            ],
+            "infixes": [
+                "ch::Integer=1"
+            ]
+        },
+        {
+            "cmd": ":SENSch:AVER:MODE",
+            "type": "AveragingMode",
+            "values": [
+                "v::Symbol in symbols"
+            ],
+            "symbols": {
+                "Auto": "AUTO",
+                "Flatten": "FLAT",
+                "Reduce": "RED",
+                "Moving": "MOV"
+            }
+        },
+        {
+            "cmd": ":SENSch:FREQ:STAR",
+            "type": "FrequencyStart",
+            "values": [
+                "v::Real"
+            ],
+            "infixes": [
+                "ch::Integer=1"
+            ]
+        },
+        {
+            "cmd": ":SENSch:FREQ:STOP",
+            "type": "FrequencyStop",
+            "values": [
+                "v::Real"
+            ],
+            "infixes": [
+                "ch::Integer=1"
+            ]
+        },
+        {
+            "cmd": ":SENSch:FREQ:CENT",
+            "type": "FrequencyCenter",
+            "values": [
+                "v::Real"
+            ],
+            "infixes": [
+                "ch::Integer=1"
+            ]
+        },
+        {
+            "cmd": ":SENSch:FREQ:SPAN",
+            "type": "FrequencySpan",
+            "values": [
+                "v::Real"
+            ],
+            "infixes": [
+                "ch::Integer=1"
+            ]
+        },
+        {
+            "cmd": ":SENSch:BAND",
+            "type": "IFBandwidth",
+            "values": [
+                "v::Real"
+            ],
+            "infixes": [
+                "ch::Integer=1"
+            ]
+        },
+        {
+            "cmd": ":SENSch:BAND:SEL",
+            "type": "FilterSelectivity",
+            "values": [
+                "v::Symbol in symbols"
+            ],
+            "symbols": {
+                "Normal": "NORM",
+                "Medium": "MED",
+                "High": "HIGH"
+            }
+        },
+        {
+            "cmd": ":SENSch:SWE:POIN",
+            "type": "NumPoints",
+            "values": [
+                "v::Integer"
+            ],
+            "infixes": [
+                "ch::Integer=1"
+            ]
+        },
+        {
+            "cmd": ":OUTP",
+            "type": "Output",
+            "values": [
+                "v::Bool"
+            ]
+        },
+        {
+            "cmd": ":SOURch:POW",
+            "type": "PowerLevel",
+            "values": [
+                "v::Real"
+            ],
+            "infixes": [
+                "ch::Integer=1"
+            ]
+        },
+        {
+            "cmd": ":DISP:TRAC:SHOW",
+            "type": "TraceDisplay",
+            "values": [
+                "v::AbstractString"
+            ],
+            "infixes": [
+                "ch::Integer=1"
+            ]
+        },
+        {
+            "cmd": ":CALCch:SMO",
+            "type": "Smoothing",
+            "values": [
+                "v::Bool"
+            ],
+            "infixes": [
+                "ch::Integer=1",
+            ]
+        },
+        {
+            "cmd": ":CALCch:SMO:APER",
+            "type": "SmoothingAperture",
+            "values": [
+                "v::Real"
+            ],
+            "infixes": [
+                "ch::Integer=1",
+            ]
+        },
+        {
+            "cmd": ":FORM:BORD",
+            "type": "TransferByteOrder",
+            "values": [
+                "v::Symbol in symbols"
+            ],
+            "symbols": {
+                "BigEndian": "NORM",
+                "LittleEndian": "SWAP"
+            }
+        },
+        {
+            "cmd": ":FORM:DATA",
+            "type": "TransferFormat",
+            "values": [
+                "v::Symbol in symbols"
+            ],
+            "symbols": {
+                "String": "ASC",
+                "Float32": "REAL,32",
+                "Float64": "REAL,64"
+            }
+        },
+        {
+            "cmd": ":TRIG:SOUR",
+            "type": "TriggerSource",
+            "values": [
+                "v::Symbol in symbols"
+            ],
+            "symbols": {
+                "InternalTrigger": "IMM",
+                "ExternalTrigger": "EXT",
+                "ManualTrigger": "MAN",
+                "MultipleTrigger": "MULT"
+            }
+        }
+    ]

--- a/deps/instruments/ZNB20.json
+++ b/deps/instruments/ZNB20.json
@@ -45,7 +45,7 @@
                 "SWR": "SWR",
                 "RealPart": "REAL",
                 "ImagPart": "IMAG",
-                "ExpandedPhase": "UPH",
+                "ExpandedPhase": "UPH"
             },
             "infixes": [
                 "ch::Integer=1"
@@ -82,7 +82,10 @@
                 "Flatten": "FLAT",
                 "Reduce": "RED",
                 "Moving": "MOV"
-            }
+            },
+            "infixes": [
+                "ch::Integer=1"
+            ]
         },
         {
             "cmd": ":SENSch:FREQ:STAR",
@@ -144,7 +147,10 @@
                 "Normal": "NORM",
                 "Medium": "MED",
                 "High": "HIGH"
-            }
+            },
+            "infixes": [
+                "ch::Integer=1"
+            ]
         },
         {
             "cmd": ":SENSch:SWE:POIN",
@@ -190,7 +196,7 @@
                 "v::Bool"
             ],
             "infixes": [
-                "ch::Integer=1",
+                "ch::Integer=1"
             ]
         },
         {
@@ -200,7 +206,7 @@
                 "v::Real"
             ],
             "infixes": [
-                "ch::Integer=1",
+                "ch::Integer=1"
             ]
         },
         {
@@ -221,7 +227,7 @@
                 "v::Symbol in symbols"
             ],
             "symbols": {
-                "String": "ASC",
+                "String": "ASCII",
                 "Float32": "REAL,32",
                 "Float64": "REAL,64"
             }
@@ -240,3 +246,4 @@
             }
         }
     ]
+}

--- a/src/Definitions.jl
+++ b/src/Definitions.jl
@@ -6,6 +6,9 @@ export AveragingTrigger
 export FrequencyStart, FrequencyStop
 export SampleRate, SweepTime
 export Timeout
+export Format
+export TransferByteOrder
+export PowerLevel
 export InstrumentException
 export @KSerror_handler
 export Amplitude
@@ -42,6 +45,24 @@ abstract type Timeout <: InstrumentProperty end
 Amplitude for a given channel.
 """
 abstract type Amplitude <: InstrumentProperty end
+
+"""
+Format of returned data. Search for `Format` in the instrument
+template files to find valid options; some examples include `:LogMagnitude`,
+`:GroupDelay`, `:PolarComplex`, etc.
+"""
+abstract type Format <: InstrumentProperty end
+
+"""
+Order of arranging bytes (biggest to smallest or vice versa) when transferring
+data from VISA instruments
+"""
+abstract type TransferByteOrder <: InstrumentProperty end
+
+"""
+Power level, in dBm, sourced by VISA instruments
+"""
+abstract type PowerLevel <: InstrumentProperty end
 
 """
 Exception to be thrown by an instrument. Fields include the instrument in error

--- a/src/InstrumentControl.jl
+++ b/src/InstrumentControl.jl
@@ -40,16 +40,17 @@ include(joinpath(dirname(@__FILE__), "instruments", "VNAs", "E5071C.jl"))
 include(joinpath(dirname(@__FILE__), "instruments","VNAs","ZNB20.jl"))
 include(joinpath(dirname(@__FILE__), "instruments", "SMB100A.jl"))
 include(joinpath(dirname(@__FILE__), "instruments", "E8257D.jl"))
+include(joinpath(dirname(@__FILE__), "instruments", "FSV.jl"))
 include(joinpath(dirname(@__FILE__), "instruments", "AWGs", "AWG5014C.jl"))
 include(joinpath(dirname(@__FILE__), "instruments", "AWGs", "M320XA", "AWGM320XA.jl"))
 include(joinpath(dirname(@__FILE__), "instruments", "GS200.jl"))
-include(joinpath(dirname(@__FILE__), "instruments", "Digitizers", "Alazar", "Alazar.jl"))
+#include(joinpath(dirname(@__FILE__), "instruments", "Digitizers", "Alazar", "Alazar.jl"))
 include(joinpath(dirname(@__FILE__), "instruments", "Digitizers", "M3102A", "DigitizerM3102A.jl"))
 
 # Not required but you can uncomment this to look for conflicting function
 # definitions that should be declared global and exported in InstrumentDefs.jl:
 
-importall .AlazarModule
+#importall .AlazarModule
 importall .AWG5014C
 importall .E5071C
 importall .E8257D
@@ -58,6 +59,7 @@ importall .SMB100A
 importall .AWGM320XA
 importall .DigitizerM3102A
 importall .ZNB20
+importall .FSV
 
 # INITIALIZATION CODE FOLLOWS
 

--- a/src/InstrumentControl.jl
+++ b/src/InstrumentControl.jl
@@ -37,7 +37,7 @@ end
 # Various instrument modules
 include(joinpath(dirname(@__FILE__), "instruments", "VNAs", "VNA.jl"))
 include(joinpath(dirname(@__FILE__), "instruments", "VNAs", "E5071C.jl"))
-# include(joinpath("instruments","VNAs","ZNB20.jl"))
+include(joinpath(dirname(@__FILE__), "instruments","VNAs","ZNB20.jl"))
 include(joinpath(dirname(@__FILE__), "instruments", "SMB100A.jl"))
 include(joinpath(dirname(@__FILE__), "instruments", "E8257D.jl"))
 include(joinpath(dirname(@__FILE__), "instruments", "AWGs", "AWG5014C.jl"))
@@ -57,7 +57,7 @@ importall .GS200
 importall .SMB100A
 importall .AWGM320XA
 importall .DigitizerM3102A
-# importall .ZNB20Module
+importall .ZNB20
 
 # INITIALIZATION CODE FOLLOWS
 

--- a/src/VISA.jl
+++ b/src/VISA.jl
@@ -234,7 +234,7 @@ unquoted(str::AbstractString) = strip(str,['"','\''])
 # end
 
 ## Convenient functions for querying arrays of numbers.
-"Retreive and parse a delimited string into an `Array{Float64,1}`."
+"Retrieve and parse a delimited string into an `Array{Float64,1}`."
 function getdata(ins::Instrument, xfer::Symbol, cmd, infixes...; delim=",")
     if xfer == :String
         for infix in infixes

--- a/src/instruments/FSV.jl
+++ b/src/instruments/FSV.jl
@@ -1,21 +1,31 @@
 module FSV
 
+export InsFSV
+export Spectrum
+export autolevel
+
 import Base: getindex, setindex!
 import VISA
 importall InstrumentControl
 import FileIO
+using ICCommon
+using AxisArrays
+import Base: search
+import ICCommon: measure
 import InstrumentControl: getdata
 
-@generate_all(InstrumentControl.meta["FSV"])
+returntype(::Type{Bool}) = (Int, Bool)
+returntype(::Type{Real}) = (Any, Float64)
+returntype(::Type{Integer}) = (Int, Int)
+fmt(v::Bool) = string(Int(v))
+fmt(v) = string(v)
 
-export InsFSV
-export Spectrum
 
-
-mutable struct InsZNB20 <: Instrument
+mutable struct InsFSV <: Instrument
     vi::(VISA.ViSession)
     writeTerminator::AbstractString
     model::AbstractString
+    tbo::Symbol #TransferByteOrder: I put it here because the instrument has no query for that.
 
     InsFSV(x) = begin
         ins = new()
@@ -23,10 +33,37 @@ mutable struct InsZNB20 <: Instrument
         ins.writeTerminator = "\n"
         ins[WriteTermCharEnable] = true
         write(ins, "*RST") #resets the instrument
+        write(ins, "INIT:CONT OFF")
         write(ins, "DISP:TRAC1 ON") #displays trace 1 on the instrument. "Format" instrument propety changes units of display
+        write(ins, "FORM:DATA REAL,32") #setting the transfer format to FLoat32
+        write(ins, "FORM:BORD SWAP")
+        ins.tbo = :LittleEndian
         return ins
     end
 end
+
+@generate_all(InstrumentControl.meta["FSV"])
+
+function setindex!(ins::InsFSV, tbo::Symbol, ::Type{TransferByteOrder})
+    if tbo == :LittleEndian
+        write(ins, "FORM:BORD SWAP")
+        ins.tbo = tbo
+    elseif tbo == :BigEndian
+        write(ins, "FORM:BORD NORM")
+        ins.tbo = tbo
+    else
+        error("Unexpected input.")
+    end
+end
+
+function getindex(ins::InsFSV, ::Type{TransferByteOrder})
+    return ins.tbo
+end
+
+function autolevel(ins::InsFSV)
+    write(ins, "ADJ:LEV")
+end
+
 
 mutable struct Spectrum <: Response
     ins::InsFSV
@@ -37,12 +74,11 @@ function measure(s::Spectrum)
     write(s.ins, "INIT:DISP ON")
     write(s.ins, "INIT") #initiate single sweep
     sleep(s.ins[SweepTime]) #wait for sweep to be over before getting data
-    npts = x.ins[NumPoints]
+    npts = s.ins[NumPoints]
     freqs = linspace(s.ins[FrequencyStart], s.ins[FrequencyStop], npts)
-    result = AxisArray(Array{Complex{Float64}}(npts, 1),
-        Axis{:f}(freqs), Axis{:power}(:Power))
     array = getdata(s.ins, s.ins[TransferFormat], "TRAC? TRACE1") #get data from instrument
-    result[Axis{:power}(:Power)] = array
-    result = transpose(result)
+    result = AxisArray(array, Axis{:Frequency}(freqs))
     return result
+end
+
 end

--- a/src/instruments/FSV.jl
+++ b/src/instruments/FSV.jl
@@ -60,6 +60,23 @@ function getindex(ins::InsFSV, ::Type{TransferByteOrder})
     return ins.tbo
 end
 
+function setindex!(ins::InsFSV, b::Bool, ::Type{Averaging})
+    if b
+        write(ins, "DISP:TRAC:MODE AVER")
+    else
+        write(ins, "DISP:TRAC:MODE WRIT")
+    end
+end
+
+function getindex(ins::InsFSV  ::Type{Averaging})
+    answer = ask(ins, "DISP:TRAC:MODE?")
+    if answer = "AVER"
+        return true
+    else
+        return false
+    end
+end
+
 function autolevel(ins::InsFSV)
     write(ins, "ADJ:LEV")
 end
@@ -72,8 +89,7 @@ end
 function measure(s::Spectrum)
     write(s.ins, "INIT:CONT OFF") #turn off continuous sweep
     write(s.ins, "INIT:DISP ON")
-    write(s.ins, "INIT") #initiate single sweep
-    sleep(s.ins[SweepTime]) #wait for sweep to be over before getting data
+    write(s.ins, "INIT; *WAI") #initiate sweeps
     npts = s.ins[NumPoints]
     freqs = linspace(s.ins[FrequencyStart], s.ins[FrequencyStop], npts)
     array = getdata(s.ins, s.ins[TransferFormat], "TRAC? TRACE1") #get data from instrument

--- a/src/instruments/FSV.jl
+++ b/src/instruments/FSV.jl
@@ -1,0 +1,48 @@
+module FSV
+
+import Base: getindex, setindex!
+import VISA
+importall InstrumentControl
+import FileIO
+import InstrumentControl: getdata
+
+@generate_all(InstrumentControl.meta["FSV"])
+
+export InsFSV
+export Spectrum
+
+
+mutable struct InsZNB20 <: Instrument
+    vi::(VISA.ViSession)
+    writeTerminator::AbstractString
+    model::AbstractString
+
+    InsFSV(x) = begin
+        ins = new()
+        ins.vi = x
+        ins.writeTerminator = "\n"
+        ins[WriteTermCharEnable] = true
+        write(ins, "*RST") #resets the instrument
+        write(ins, "DISP:TRAC1 ON") #displays trace 1 on the instrument. "Format" instrument propety changes units of display
+        return ins
+    end
+end
+
+mutable struct Spectrum <: Response
+    ins::InsFSV
+end
+
+function measure(s::Spectrum)
+    write(s.ins, "INIT:CONT OFF") #turn off continuous sweep
+    write(s.ins, "INIT:DISP ON")
+    write(s.ins, "INIT") #initiate single sweep
+    sleep(s.ins[SweepTime]) #wait for sweep to be over before getting data
+    npts = x.ins[NumPoints]
+    freqs = linspace(s.ins[FrequencyStart], s.ins[FrequencyStop], npts)
+    result = AxisArray(Array{Complex{Float64}}(npts, 1),
+        Axis{:f}(freqs), Axis{:power}(:Power))
+    array = getdata(s.ins, s.ins[TransferFormat], "TRAC? TRACE1") #get data from instrument
+    result[Axis{:power}(:Power)] = array
+    result = transpose(result)
+    return result
+end

--- a/src/instruments/FSV.jl
+++ b/src/instruments/FSV.jl
@@ -72,8 +72,7 @@ end
 function measure(s::Spectrum)
     write(s.ins, "INIT:CONT OFF") #turn off continuous sweep
     write(s.ins, "INIT:DISP ON")
-    write(s.ins, "INIT") #initiate single sweep
-    sleep(s.ins[SweepTime]) #wait for sweep to be over before getting data
+    write(s.ins, "INIT; *WAI") #initiate single sweep
     npts = s.ins[NumPoints]
     freqs = linspace(s.ins[FrequencyStart], s.ins[FrequencyStop], npts)
     array = getdata(s.ins, s.ins[TransferFormat], "TRAC? TRACE1") #get data from instrument

--- a/src/instruments/FSV.jl
+++ b/src/instruments/FSV.jl
@@ -68,9 +68,9 @@ function setindex!(ins::InsFSV, b::Bool, ::Type{Averaging})
     end
 end
 
-function getindex(ins::InsFSV  ::Type{Averaging})
+function getindex(ins::InsFSV,  ::Type{Averaging})
     answer = ask(ins, "DISP:TRAC:MODE?")
-    if answer = "AVER"
+    if answer == "AVER"
         return true
     else
         return false

--- a/src/instruments/VNAs/VNA.jl
+++ b/src/instruments/VNAs/VNA.jl
@@ -86,13 +86,6 @@ function measure(x::FrequencySweep)
 end
 
 """
-Format of returned data. Search for `VNA.Format` in the instrument
-template files to find valid options; some examples include `:LogMagnitude`,
-`:GroupDelay`, `:PolarComplex`, etc.
-"""
-abstract type Format <: InstrumentProperty end
-
-"""
 Graph layout on the VNA display. Specify with a matrix of integers.
 
 The following example will have graph 1 occupying the top half of the screen,

--- a/src/instruments/VNAs/ZNB20.jl
+++ b/src/instruments/VNAs/ZNB20.jl
@@ -47,7 +47,7 @@ function measure(s::SParamSweep)
     array = getdata(s.ins, s.ins[TransferFormat], "CALC1:DATA? SDAT") #get data from instrument
     data = [Complex{T}(array[i],array[i+1]) for i in 1:2:length(array)] #reformatting
     data = reinterpret(Complex{Float64}, data)
-    result[Axis{:sparam}(s.Sparam)] = data
+    result[Axis{:sparam}(Symbol(s.Sparam))] = data
     result = transpose(result)
     return result
 end

--- a/src/instruments/VNAs/ZNB20.jl
+++ b/src/instruments/VNAs/ZNB20.jl
@@ -1,38 +1,18 @@
 module ZNB20
 
-## Import packages
+import Base: getindex, setindex!
 import VISA
-import Base: cd, pwd
-
-## Import our modules
-importall InstrumentControl                 # All the stuff in InstrumentDefs, etc.
+importall InstrumentControl
+import FileIO
 import InstrumentControl: getdata
-
-importall InstrumentControl.VNA
-import InstrumentControl.VNA: datacmd
 
 @generate_all(InstrumentControl.meta["ZNB20"])
 
 export ZNB20
+export SParamSweep
 
-export AutoSweepTime
-export Bandwidth
-export DisplayUpdate
-export SweepTime
-export Window
 
-export cd
-export hidetrace
-export lstrace
-export mktrace
-export pwd
-export rmtrace
-export showtrace
-export stimdata
-
-znbool(a) = (Bool(a) ? "ON" : "OFF")
-
-mutable struct InsZNB20 <: InstrumentVNA
+mutable struct InsZNB20 <: Instrument
     vi::(VISA.ViSession)
     writeTerminator::AbstractString
     model::AbstractString
@@ -41,301 +21,35 @@ mutable struct InsZNB20 <: InstrumentVNA
         ins = new()
         ins.vi = x
         ins.writeTerminator = "\n"
-        ins.model = "ZNB20"
-        VISA.viSetAttribute(ins.vi, VISA.VI_ATTR_TERMCHAR_EN, UInt64(1))
-        ins
-    end
-
-    InsZNB20() = new()
-end
-
-# subtypesArray = [
-# ]
-#
-# # Create all the concrete types we need using the generate_properties function.
-# for ((subtypeSymb,supertype) in subtypesArray)
-#     generate_properties(subtypeSymb, supertype)
-# end
-
-responseDictionary = Dict(
-
-    :TransferByteOrder => Dict("NORM" => :BigEndianTransfer,
-                               "SWAP" => :LittleEndianTransfer),
-
-    :Format            => Dict("MLIN" => :LinearMagnitude,
-                               "MLOG" => :LogMagnitude,
-                               "PHAS" => :Phase,
-                               "UPH"  => :ExpandedPhase,  # Is it?
-                               "POL"  => :PolarLinear, # Is it though?
-                               "SMIT" => :Smith, # Is it?
-                               "ISM"  => :SmithAdmittance, #Is it?
-                               "GDEL" => :GroupDelay,
-                               "REAL" => :RealPart,
-                               "IMAG" => :ImagPart,
-                               "SWR"  => :SWR),
-
-    :OscillatorSource  => Dict("INT" => :InternalOscillator,
-                               "EXT" => :ExternalOscillator),
-
-    :TriggerSlope      => Dict("POS"  => :RisingTrigger,
-                               "NEG"  => :FallingTrigger),
-
-    :TriggerSource     => Dict("IMM"  => :InternalTrigger,
-                               "EXT"  => :ExternalTrigger,
-                               "MAN"  => :ManualTrigger,
-                               "MULT" => :MultipleTrigger),
-
-)
-
-generate_handlers(ZNB20, responseDictionary)
-
-code(ins::ZNB20, ::Type{TransferFormat{ASCIIString}}) = "ASC,0"
-code(ins::ZNB20, ::Type{TransferFormat{Float32}}) = "REAL,32"
-code(ins::ZNB20, ::Type{TransferFormat{Float64}}) = "REAL,64"
-TransferFormat(ins::ZNB20, x::AbstractString) = begin
-    if x=="ASC,0"
-        return TransferFormat{ASCIIString}
-    elseif x=="REAL,32"
-        return TransferFormat{Float32}
-    elseif x=="REAL,64"
-        return TransferFormat{Float64}
-    else
-        error("Transfer format error.")
+        ins[WriteTermCharEnable] = true
+        write(ins, "*RST") #reset the instrument; this makes a default channel 1 with a default trace
+        write(ins, "CONF:CHAN1:TRAC:REN "*quoted("MyTrace")) #renames the default trace
+        write(ins, "SYST:DISP:UPD ON") #displays the trace on the Instrument. "Format" instrument propety changes units of display
+        return ins
     end
 end
 
-"Configure or inspect. Does the instrument choose the minimum sweep time?"
-abstract AutoSweepTime <: InstrumentProperty
-
-"Configure or inspect. Measurement / resolution bandwidth. May be rounded."
-abstract Bandwidth     <: InstrumentProperty
-
-"Configure or inspect. Display updates during measurement."
-abstract DisplayUpdate <: InstrumentProperty
-
-"Configure or inspect. Adjust time it takes to complete a sweep (all partial measurements)."
-abstract SweepTime     <: InstrumentProperty
-
-"`InstrumentProperty`: Window."
-abstract Window        <: InstrumentProperty
-
-### Configure and inspect
-
-"""
-[CALCULATE#:PARAMETER:SELECT](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/3c03effa6de64ee5.htm)
-
-Select an active trace. Channel `ch` defaults to 1.
-"""
-function setindex!(ins::ZNB20, name::AbstractString, ::Type{ActiveTrace}, ch::Int=1)
-    write(ins, "CALCulate"*string(ch)":PARameter:SELect "*quoted(name))
+mutable struct SParamSweep <: Response
+    ins::InsZNB20
+    Sparam::String
 end
 
-"""
-[SENSE#:SWEEP:TIME:AUTO](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/4e1073e7fde645a8.htm)
-
-Determines whether or not the instrument chooses the minimum sweep time,
-including all partial measurements. Channel `ch` defaults to 1.
-"""
-function setindex!(ins::ZNB20, b::Bool, ::Type{AutoSweepTime}, ch::Int=1)
-    write(ins, "SENSe"*string(ch)*":SWEep:TIME:AUTO "*znbool(b))
-end
-
-"""
-[SENSE#:BWIDTH:RESOLUTION](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/dd1fd694e0ce4dd8.htm)
-
-Set the measurement bandwidth between 1 Hz and 1 MHz
-(option ZNBT-K17 up to 10 MHz).
-Channel `ch` defaults to 1.
-"""
-function setindex!(ins::ZNB20, bw::Float64, ::Type{Bandwidth}, ch::Int=1)
-    write(ins, "SENSe"*string(ch)*":BWIDth:RESolution "*string(bw))
-end
-
-"""
-[SYSTEM:DISPLAY:UPDATE](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/d36e114067.htm)
-
-Switches display update on / off.
-"""
-function setindex!(ins::ZNB20, b::Bool, ::Type{DisplayUpdate})
-    write(ins, "SYSTem:DISPlay:UPDate "*znbool(b))
-end
-
-"""
-[SENSE#:SWEEP:POINTS](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/68b77d9828354b78.htm)
-
-Define measurement points per sweep. Channel `ch` defaults to 1.
-"""
-function setindex!(ins::ZNB20, n::Int, ::Type{NumPoints}, ch::Int=1)
-    write(ins, "SENSe"*string(ch)*":SWEep:POINts "*string(n))
-end
-
-"""
-[SENSE1:ROSCILLATOR:SOURCE](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/4314a7accd124cd8.htm)
-
-Select oscillator source: `InternalOscillator`, `ExternalOscillator`
-"""
-function setindex!{T<:OscillatorSource}(ins::ZNB20, ::Type{T})
-    write(ins, "SENSe1:ROSCillator:SOURce "*code(ins,T))
-end
-
-"""
-[SENSE#:SWEEP:TIME](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/8227ae4383e449fe.htm)
-
-Define the time to complete a sweep, including all partial measurements.
-Channel `ch` defaults to 1.
-"""
-function setindex!(ins::ZNB20, time, ::Type{SweepTime}, ch::Int=1)
-    write(ins, "SENSe"*string(ch)*":SWEep:TIME "*string(time))
-end
-
-"""
-[TRIGGER#:SEQUENCE:SLOPE](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/cbc5449b57664ad3.htm)
-
-Configure the trigger slope: `RisingTrigger`, `FallingTrigger`.
-Channel `ch` defaults to 1.
-"""
-function configure{T<:TriggerSlope}(ins::ZNB20, ::Type{T}, ch::Int=1)
-    write(ins, "TRIGger"*string(ch)*":SLOPe "*code(ins, T))
-end
-
-"""
-[TRIGger#:SEQuence:SOURce](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/9c62999c5a1642f2.htm)
-
-Configure the trigger source: `InternalTrigger`, `ExternalTrigger`, `ManualTrigger`,
-`MultipleTrigger`. Channel `ch` defaults to 1.
-"""
-function configure{T<:TriggerSource}(ins::ZNB20, ::Type{T}, ch::Int=1)
-    write(ins, "TRIGger"*string(ch)*":SOURce "*code(ins, T))
-end
-
-"""
-[CALCULATE#:FORMAT](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/132d40cd4d1d43c4.htm)
-
-Configure the format of the active trace:
-`LinearMagnitude`, `LogMagnitude`, `Phase`, `ExpandedPhase`, `PolarLinear`,
-`Smith`, `SmithAdmittance`, `GroupDelay`, `RealPart`, `ImagPart`, `SWR`.
-Channel `ch` defaults to 1.
-"""
-function configure{T<:Format}(ins::ZNB20, ::Type{T}, ch::Int=1)
-    write(ins, "CALCulate"*string(ch)*":FORMat "*code(ins,T))
-end
-
-"""
-[DISPLAY:WINDOW#:STATE](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/065c895d5a2c4230.htm)
-
-Turn a window on or off.
-"""
-function setindex!(ins::ZNB20, b::Bool, ::Type{Window}, win::Int)
-    write(ins,"DISPlay:WINDow"*string(win)*":STATe "*znbool(b))
-end
-
-"""
-[CALCULATE#:PARAMETER:SELECT](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/3c03effa6de64ee5.htm)
-
-Query an active trace. Channel `ch` defaults to 1.
-"""
-function getindex(ins::ZNB20, ::Type{ActiveTrace}, ch::Int=1)
-    unquoted(ask(ins, "CALCulate"*string(ch)":PARameter:SELect "*quoted(name)))
-end
-
-"""
-[SENSE#:SWEEP:TIME:AUTO](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/4e1073e7fde645a8.htm)
-
-Does the instrument choose the minimum sweep time,
-including all partial measurements? Channel `ch` defaults to 1.
-"""
-function getindex(ins::ZNB20, ::Type{AutoSweepTime}, ch::Int=1)
-    Bool(parse(ask(ins, "SENSe"*string(ch)*":SWEep:TIME:AUTO?")))
-end
-
-"""
-[SENSE#:BWIDTH:RESOLUTION](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/dd1fd694e0ce4dd8.htm)
-
-Inspect the measurement bandwidth.
-Channel `ch` defaults to 1.
-"""
-function getindex(ins::ZNB20, ::Type{Bandwidth}, ch::Int=1)
-    parse(write(ins, "SENSe"*string(ch)*":BWIDth:RESolution?"))
-end
-
-"""
-[SYSTEM:DISPLAY:UPDATE](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/d36e114067.htm)
-
-Is the display updating?
-"""
-function getindex(ins::ZNB20, ::Type{DisplayUpdate})
-    Bool(parse(ask(ins, "SYSTem:DISPlay:UPDate?")))
-end
-
-"""
-[SENSE#:SWEEP:POINTS](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/68b77d9828354b78.htm)
-
-How many measurement points per sweep? Channel `ch` defaults to 1.
-"""
-function getindex(ins::ZNB20, ::Type{NumPoints}, ch::Int=1)
-    parse(ask(ins, "SENSe"*string(ch)*":SWEep:POINts?"))
-end
-
-"""
-[SENSE1:ROSCILLATOR:SOURCE](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/4314a7accd124cd8.htm)
-
-Inspect oscillator source: `InternalOscillator`.
-"""
-function getindex(ins::ZNB20, ::Type{OscillatorSource})
-    OscillatorSource(ins,ask(ins, "SENSe1:ROSCillator:SOURce?"))
-end
-
-"""
-[SENSE#:SWEEP:TIME](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/8227ae4383e449fe.htm)
-
-Define the time to complete a sweep, including all partial measurements.
-Channel `ch` defaults to 1.
-"""
-function getindex(ins::ZNB20, ::Type{SweepTime}, ch::Int=1)
-    parse(ask(ins, "SENSe"*string(ch)*":SWEep:TIME?"))
-end
-
-"""
-[TRIGGER#:SEQUENCE:SLOPE](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/cbc5449b57664ad3.htm)
-
-Inspect the trigger slope. Channel `ch` defaults to 1.
-"""
-function getindex(ins::ZNB20, ::Type{TriggerSlope}, ch::Int=1)
-    TriggerSlope(ins, write(ins, "TRIGger"*string(ch)*":SLOPe?"))
-end
-
-"""
-[TRIGger#:SEQuence:SOURce](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/ZNB_ZNBT_WebHelp_en.htm)
-
-Inspect the trigger source. Channel `ch` defaults to 1.
-"""
-function getindex(ins::ZNB20, ::Type{TriggerSource}, ch::Int=1)
-    TriggerSource(ins, ask(ins, "TRIGger"*string(ch)*":SOURce?"))
-end
-
-"""
-[CALCULATE#:FORMAT](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/132d40cd4d1d43c4.htm)
-
-Inspect the format of the active trace. Channel `ch` defaults to 1.
-"""
-function getindex(ins::ZNB20, ::Type{Format}, ch::Int=1)
-    Format(unquoted(ask(ins, "CALCulate"*string(ch)*":FORMat?")))
-end
-
-"""
-Determines if a window exists, by window number. See `lswindow`.
-"""
-function getindex(ins::ZNB20, ::Type{Window}, win::Int)
-    nums = lswindows(ins)[1]
-    findfirst(nums,win) != 0
-end
-
-"""
-Determines if a window exists, by window name. See `lswindow`.
-"""
-function getindex(ins::ZNB20, ::Type{Window}, wname::AbstractString)
-    names = lswindows(ins)[2]
-    findfirst(names,wname) != 0
+function measure(s::SParamSweep)
+    write(s.ins, "CALC1:PAR:MEAS " *quoted("MyTrace")*", "*quoted(s.Sparam)) #assign a measurement to a trace
+    write(s.ins, "INIT1:CONT OFF") #turn off continuous sweep in channel 1
+    write(s.ins, "DISP:WIND1:TRAC:EFE "*quoted("MyTrace"))
+    write(s.ins, "INIT1") #initiate single sweep
+    sleep(s.ins[SweepTime]) #wait for sweep to be over before getting data
+    npts = x.ins[NumPoints]
+    freqs = linspace(s.ins[FrequencyStart], s.ins[FrequencyStop], npts)
+    result = AxisArray(Array{Complex{Float64}}(npts, 1),
+        Axis{:f}(freqs), Axis{:sparam}(Symbol(s.Sparam)))
+    array = getdata(s.ins, s.ins[TransferFormat], "CALC1:DATA? SDAT") #get data from instrument
+    data = [Complex{T}(array[i],array[i+1]) for i in 1:2:length(array)] #reformatting
+    data = reinterpret(Complex{Float64}, data)
+    result[Axis{:sparam}(s.Sparam)] = data
+    result = transpose(result)
+    return result
 end
 
 ## Other commands
@@ -353,51 +67,6 @@ function cd(ins::ZNB20, dir::AbstractString)
     end
 end
 
-"""
-[DISPLAY:WINDOW#:TRACE#:DELETE](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/35e75331f5ce4fce.htm)
-
-Releases the assignment of window trace `wtrace` to window `win`.
-"""
-function hidetrace(ins::ZNB20, win::Int, wtrace::Int)
-    write(ins, "DISPlay:WINDow"*string(win)*":TRACe"*string(wtrace)*":DELETE")
-end
-
-"""
-[CALCULATE#:PARAMETER:CATALOG?](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/2ce049f1af684d21.htm)
-
-Report the traces assigned to a given channel.
-"""
-function lstrace(ins::ZNB20, ch::Int)
-    res = ask(ins, "CALCulate"*string(ch)*":PARameter:CATALOG?")
-end
-
-"""
-[DISPLAY:CATALOG?](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/abdd1db5dc0c48ee.htm)
-
-Report the windows and their names in a tuple: (`arrNums::Array{Int64,1}`,
-    `arrNames::Array{SubString{ASCIIString},1})`).
-"""
-function lswindows(ins::ZNB20)
-    wins = unquoted(ask(ins, "DISPlay:CATalog?"))
-    arr = split(wins,",")
-    arrNums = arr[1:2:end]
-    arrNames = arr[2:2:end]
-    arrNums = [parse(x)::Int for x in arrNums]
-
-    (arrNums, arrNames)
-end
-
-"""
-[CALCulate#:PARameter:SDEFine](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/e75d49e2a14541c5.htm)
-
-Create a new trace with `name` and measurement `parameter` on channel `ch`,
-defaulting to 1.
-"""
-function mktrace(ins::ZNB20, name::AbstractString, parameter, ch::Int=1)
-    cmd = "CALCulate"*ch
-    cmd = cmd*":PARameter:SDEFine "*quoted(name)*","*quoted(parameter)
-    write(ins, cmd)
-end
 
 """
 [MMEMory:CDIRectory?](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/d36e87010.htm)
@@ -406,87 +75,6 @@ Print the working directory.
 """
 function pwd(ins::ZNB20)
     unquoted(ask(ins, "MMEMory:CDIRectory?"))
-end
-
-"""
-[CALCULATE#:PARAMETER:DELETE](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/0763f74d0a2d4d61.htm)
-
-Remove trace with name `name` from channel `ch`, defaulting to 1.
-"""
-function rmtrace(ins::ZNB20, name::AbstractString, ch::Int=1)
-    write(ins, "CALCulate"*string(ch)*":PARameter:DELete "*quoted(name))
-end
-
-"""
-[CALCulate#:PARameter:DELete:CALL](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/8d937272d97244fb.htm)
-
-Deletes all traces in the given channel `ch`, defaulting to 1.
-"""
-function rmtrace(ins::ZNB20, ch::Int=1)
-    write(ins, "CALCulate"*string(ch)*":PARameter:DELete:CALL")
-end
-
-# """
-# [CALCulate:PARameter:DELete:ALL](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/d36e69977.htm)
-#
-# Deletes all traces in all channels.
-# """
-# function rmtrace(ins::ZNB20)
-#     write(ins, "CALCulate:PARameter:DELete:ALL")
-# end
-
-"""
-[DISPLAY:WINDOW#:TRACE#:FEED](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/58dad852e7db48a0.htm)
-
-Show a trace named `name` in window `win::Int` as
-window trace number `wtrace::Int`.
-"""
-function showtrace(ins::ZNB20, name::AbstractString, win::Int, wtrace::Int)
-    write(ins, "DISPlay:WINDow"*string(win)*
-        ":TRACe"*string(wtrace)*":FEED "*quoted(name))
-end
-
-"""
-[CALCulate#:DATA:STIMulus?](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/038ef1cf7a044e85.htm)
-
-Read the stimulus values for the given channel (default ch. 1).
-"""
-function stimdata(ins::ZNB20, ch::Int=1)
-    xfer = ins[TransferFormat]
-    getdata(ins, xfer, "CALCulate"*string(ch)*":DATA:STIMulus?")
-end
-
-"""
-[CALCULATE#:DATA](https://www.rohde-schwarz.com/webhelp/znb_znbt_webhelp_en_6/Content/a9ce754f8a7c483a.htm)
-
-Retrieve data from the active trace or memory trace.
-Pass the desired format as a string, e.g. "fdat" for
-formatted trace data. See the link above for details.
-
-Channel `ch` defaults to 1.
-"""
-function data(ins::ZNB20, ch::Integer=1; format::VNA.Processing=VNA.Formatted)
-    xfer = ins[TransferFormat]
-    array = getdata(ins, xfer, "CALCulate"*string(ch)*":DATA? "*datacmd(ins,format))
-    _reformat(array, Val{format})
-end
-
-datacmd(x::ZNB20, ::Type{VNA.Formatted}) = "fdat"
-datacmd(x::ZNB20, ::Type{VNA.Mathematics}) = "mdat"
-datacmd(x::ZNB20, ::Type{VNA.Calibrated}) = "sdat"
-datacmd(x::ZNB20, ::Type{VNA.Factory}) = "ncd"
-datacmd(x::ZNB20, ::Type{VNA.Raw}) = "ucd"
-
-function _reformat{T}(x, ::Type{Val{T}})
-    x
-end
-
-function _reformat{T}(x::Array{T,1}, ::Type{Val{:sdat}})
-    [Complex{T}(x[i],x[i+1]) for i in 1:2:length(x)]
-end
-
-function _reformat{T}(x::Array{T,1}, ::Type{Val{:mdat}})
-    [Complex{T}(x[i],x[i+1]) for i in 1:2:length(x)]
 end
 
 end


### PR DESCRIPTION
Did so via Andrew's metaprogramming approach. Note, however, that the ZNB20 module is not integrated with the VNA module (due to some incompatibilities between the way that the ZNB20 instrument works and some assumptions made in the VNA module)